### PR TITLE
[WIP] Add tracing-error support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ tokio = {version = "0.3", default-features = false, features = ["rt", "macros"]}
 tracing = {version = "0.1"}
 tracing-futures = {version = "0.2", default-features = false, features = ["std-future"]}
 tracing-subscriber = {version = "0.2", default-features = false, features = ["env-filter", "fmt"]}
+tracing-error = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,11 @@ fn expand_tracing_init() -> Tokens {
   #[cfg(feature = "trace")]
   quote! {
     let _guard = {
+      use ::tracing_subscriber::layer::SubscriberExt;
       let subscriber = ::tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(::tracing_subscriber::EnvFilter::from_default_env())
-        .finish();
+        .finish()
+        .with(::tracing_error::ErrorLayer::default());
       ::tracing::subscriber::set_default(subscriber)
     };
   }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -67,6 +67,33 @@ async fn trace_with_tokio_attribute() {
 }
 
 
+#[cfg(feature = "trace")]
+#[test_env_log::test]
+fn test_tracing_error() {
+  use tracing::{span, Level};
+  use tracing_error::SpanTrace;
+
+  let captured_inner_span;
+  let captured_outer_span;
+
+  {
+    let outer_span = span!(Level::ERROR, "outer");
+    let _guard = outer_span.enter();
+    {
+      let inner_span = span!(Level::ERROR, "inner");
+      let _guard = inner_span.enter();
+        captured_inner_span = SpanTrace::capture();
+    }
+    captured_outer_span = SpanTrace::capture();
+  }
+  assert!(format!("{}", captured_inner_span).contains("inner"));
+  assert!(format!("{}", captured_inner_span).contains("outer"));
+
+  assert!( ! format!("{}", captured_outer_span).contains("inner"));
+  assert!(format!("{}", captured_outer_span).contains("outer"));
+}
+
+
 mod local {
   use super::Error;
 


### PR DESCRIPTION
For SpanTrace to work, the tracing subscriber
needs an additional ErrorLayer.
See #2