### PR TITLE
Capture `trace` logs with `libtest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+-----
+- Changed `tracing-subscriber` to capture output with libtest.
+- Bumped minimum `tracing-subscriber` version to 0.2.12.
+
 0.2.6
 -----
 - Introduced support for `RUST_LOG_SPAN_EVENTS` environment variable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,4 @@ logging = {version = "0.4", package = "log"}
 tokio = {version = "1.0", default-features = false, features = ["rt", "macros"]}
 tracing = {version = "0.1"}
 tracing-futures = {version = "0.2", default-features = false, features = ["std-future"]}
-tracing-subscriber = {version = "0.2", default-features = false, features = ["env-filter", "fmt"]}
+tracing-subscriber = {version = "0.2.12", default-features = false, features = ["env-filter", "fmt"]}

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ enabling the `log` or `trace` feature, respectively). E.g.,
 ```toml
 [dev-dependencies]
 env_logger = "*"
-tracing-subscriber = {version = "0.2", features = ["chrono", "env-filter", "fmt"]}
+tracing-subscriber = {version = "0.2.12", features = ["chrono", "env-filter", "fmt"]}
 ```
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ fn expand_tracing_init() -> Tokens {
       let subscriber = ::tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(::tracing_subscriber::EnvFilter::from_default_env())
         .with_span_events(__internal_event_filter)
+        .with_test_writer()
         .finish();
       let _ = ::tracing::subscriber::set_global_default(subscriber);
     }


### PR DESCRIPTION
Commit message:

Configures the tracing subscriber to allow log messages to be captured
by `libtest`. This makes it a bit clearer whether log messages are in
the scope of your test when multiple tests are running for async tests.

As the method on `tracing_subscriber::fmt::SubscriberBuilder` was added
in `0.2.12`, this commit also updates the README and the changelog to
reflect that change.

---

Hi,

I'm not certain if this a desired feature but it seemed useful. My use case is when running a few different async tests with similar output this should make it easier to figure out which output corresponds to which test.

https://docs.rs/tracing-subscriber/0.2.17/tracing_subscriber/fmt/struct.SubscriberBuilder.html#method.with_test_writer

^ link to this function in the documentation.