### PR TITLE
Allow RUST_LOG_SPAN_EVENTS=off

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ log synthesized events at points in the span lifecycle. Set the variable
 to a comma-separated list of events you want to see. For example,
 `RUST_LOG_SPAN_EVENTS=full` or `RUST_LOG_SPAN_EVENTS=new,close`.
 
-Valid events are `new`, `enter`, `exit`, `close`, `active`, and `full`.
+Valid events are `off`, `new`, `enter`, `exit`, `close`, `active`, and `full`.
 See the [`tracing_subscriber` docs][tracing-events-docs-rs] for details
 on what the events mean.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ fn expand_tracing_init() -> Tokens {
               .to_ascii_lowercase()
               .split(",")
               .map(|filter| match filter.trim() {
+                "off" => FmtSpan::NONE,
                 "new" => FmtSpan::NEW,
                 "enter" => FmtSpan::ENTER,
                 "exit" => FmtSpan::EXIT,
@@ -120,7 +121,7 @@ fn expand_tracing_init() -> Tokens {
                 "full" => FmtSpan::FULL,
                 _ => panic!("test-env-log: RUST_LOG_SPAN_EVENTS must contain filters separated by `,`.\n\t\
                   For example: `active` or `new,close`\n\t\
-                  Supported filters: new, enter, exit, close, active, full\n\t\
+                  Supported filters: off, new, enter, exit, close, active, full\n\t\
                   Got: {}", value),
               })
               .fold(FmtSpan::NONE, |acc, filter| filter | acc)


### PR DESCRIPTION
For consistency with RUST_LOG=off allow turning of span logging.

Closes #16 
