### PR TITLE
build: upgrade tracing-subscriber to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-env-log"
-version = "0.2.7"
+version = "0.3.0"
 authors = ["Daniel Mueller <deso@posteo.net>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -45,4 +45,4 @@ logging = {version = "0.4", package = "log"}
 tokio = {version = "1.0", default-features = false, features = ["rt", "macros"]}
 tracing = {version = "0.1"}
 tracing-futures = {version = "0.2", default-features = false, features = ["std-future"]}
-tracing-subscriber = {version = "0.2.17", default-features = false, features = ["env-filter", "fmt"]}
+tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}


### PR DESCRIPTION
[tracing-subscriber 0.3.0](https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.0) was released 3 days ago in order to fix [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159.html). As `test-env-log` has a 0.2 dependency, it would be best if this dependency was updated to 0.3 to avoid usage of `chrono` and support new `tracing-*` releases.